### PR TITLE
Add build scripts for Android and Windows

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,123 @@
+## BUILD INSTRUCTIONS
+
+### Android
+#### Recommended tools:
+
+- Android NDK 28
+- Cmake
+- Bash
+
+```
+export NDK=path/to/android-ndk
+./build_android_all.sh
+```
+
+Script will build artifacts for Android arm, arm64, x86 and x86_64, Debug and Release configurations
+
+### Windows
+
+#### Requisites:
+
+- Visual Studio 16 2019 (MSVC 19)
+- Cmake
+
+```
+build_windows_all.bat
+```
+
+Script will build artifacts for Windows x86 and x86_64, Debug and Release configurations
+
+### Build artifacts
+
+Scripts generate this artifact tree, then conan packages can be created from repo's root folder
+
+```
+conan export-pkg . fdk-aac/<version>@dn/<channel> -pr <profile> [-f]
+```
+
+
+```text
+
+├───install
+    ├───Windows
+    │   ├───Debug
+    │   │   ├───include
+    │   │   │   └───fdk-aac
+    │   │   │           aacdecoder_lib.h
+    │   │   │           aacenc_lib.h
+    │   │   │           FDK_audio.h
+    │   │   │           genericStds.h
+    │   │   │           machine_type.h
+    │   │   │           syslib_channelMapDescr.h
+    │   │   │
+    │   │   └───lib
+    │   │       ├───x86
+    │   │       │       fdk-aac.lib
+    │   │       │
+    │   │       └───x86_64
+    │   │               fdk-aac.lib
+    │   │
+    │   └───Release
+    │       ├───include
+    │       │   └───fdk-aac
+    │       │           aacdecoder_lib.h
+    │       │           aacenc_lib.h
+    │       │           FDK_audio.h
+    │       │           genericStds.h
+    │       │           machine_type.h
+    │       │           syslib_channelMapDescr.h
+    │       │
+    │       └───lib
+    │           ├───x86
+    │           │       fdk-aac.lib
+    │           │
+    │           └───x86_64
+    │                   fdk-aac.lib
+    └───Android
+        ├───Debug
+        │   ├───include
+        │   │   └───fdk-aac
+        │   │           aacdecoder_lib.h
+        │   │           aacenc_lib.h
+        │   │           FDK_audio.h
+        │   │           genericStds.h
+        │   │           machine_type.h
+        │   │           syslib_channelMapDescr.h
+        │   │
+        │   └───lib
+        │       ├───armeabi-v7a
+        │       │       libfdk-aac_armeabi-v7a.a
+        │       │
+        │       ├───arm64-v8a
+        │       │       libfdk-aac_arm64-v8a.a
+        │       │
+        │       ├───x86
+        │       │       libfdk-aac_x86.a
+        │       │
+        │       └───x86_64
+        │               libfdk-aac_x86_64.a
+        │
+        └───Release
+            ├───include
+            │   └───fdk-aac
+            │           aacdecoder_lib.h
+            │           aacenc_lib.h
+            │           FDK_audio.h
+            │           genericStds.h
+            │           machine_type.h
+            │           syslib_channelMapDescr.h
+            │
+            └───lib
+                ├───armeabi-v7a
+                │       libfdk-aac_armeabi-v7a.a
+                │
+                ├───arm64-v8a
+                │       libfdk-aac_arm64-v8a.a
+                │
+                ├───x86
+                │       libfdk-aac_x86.a
+                │
+                └───x86_64
+                        libfdk-aac_x86_64.a
+
+```

--- a/BUILD.md
+++ b/BUILD.md
@@ -32,7 +32,7 @@ Script will build artifacts for Windows x86 and x86_64, Debug and Release config
 Scripts generate this artifact tree, then conan packages can be created from repo's root folder
 
 ```
-conan export-pkg . fdk-aac/<version>@dn/<channel> -pr <profile> [-f]
+conan export-pkg . fdk_aac/<version>@dn/<channel> -pr <profile> [-f]
 ```
 
 

--- a/build_android_all.sh
+++ b/build_android_all.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+# --- Ensure bash ---
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "❌ This script must be executed with bash."
+  echo "   Use: bash build_android_all.sh"
+  exit 1
+fi
+
+set -euo pipefail
+
+# --- Configuration (overridable via environment variables) ---
+NDK="${NDK:-}"
+API="${API:-26}"
+OS_NAME="${OS_NAME:-Android}"
+
+SRC_DIR="${SRC_DIR:-$PWD}"
+
+# Required output layout:
+# install/<OS>/<Debug|Release>/lib/<ABI>/
+OUT_ROOT="${OUT_ROOT:-$PWD/install}"
+BUILD_ROOT="${BUILD_ROOT:-$PWD/build}"
+
+ABIS=("armeabi-v7a" "arm64-v8a" "x86" "x86_64")
+CONFIGS=("Debug" "Release")
+
+# --- Environment validation ---
+echo "🔎 Validating environment..."
+
+if [[ -z "$NDK" ]]; then
+  echo "❌ NDK variable is not defined."
+  echo "   Please export it before running:"
+  echo "   export NDK=/path/to/android-ndk"
+  exit 1
+fi
+
+if [[ ! -d "$NDK" ]]; then
+  echo "❌ NDK not found at: $NDK"
+  exit 1
+fi
+
+if [[ ! -f "$NDK/build/cmake/android.toolchain.cmake" ]]; then
+  echo "❌ android.toolchain.cmake not found inside the NDK."
+  exit 1
+fi
+
+if ! command -v cmake >/dev/null 2>&1; then
+  echo "❌ cmake is not installed or not available in PATH."
+  exit 1
+fi
+
+if [[ ! -f "$SRC_DIR/CMakeLists.txt" ]]; then
+  echo "❌ CMakeLists.txt not found in: $SRC_DIR"
+  echo "   Are you inside the fdk-aac repository?"
+  exit 1
+fi
+
+echo "✅ Environment OK"
+echo
+echo "OS       : $OS_NAME"
+echo "NDK      : $NDK"
+echo "API      : $API"
+echo "Source   : $SRC_DIR"
+echo "Install  : $OUT_ROOT/$OS_NAME/<Debug|Release>/(lib|include)"
+echo "Build    : $BUILD_ROOT/$OS_NAME/<ABI>/<Debug|Release>"
+echo
+
+mkdir -p "$OUT_ROOT" "$BUILD_ROOT"
+
+# --- Build loop ---
+for ABI in "${ABIS[@]}"; do
+  for CFG in "${CONFIGS[@]}"; do
+    CFG_LC="$(echo "$CFG" | tr '[:upper:]' '[:lower:]')"  # Debug -> debug, Release -> release
+
+    echo "======================================"
+    echo "🚀 Building: $OS_NAME | ABI: $ABI | Config: $CFG (API $API)"
+    echo "======================================"
+
+    BUILD_DIR="$BUILD_ROOT/$OS_NAME/$ABI/$CFG"
+    PREFIX="$OUT_ROOT/$OS_NAME/$CFG"   # ABI will be placed under lib/<ABI> later
+
+    rm -rf "$BUILD_DIR"
+    mkdir -p "$BUILD_DIR"
+
+    cmake -S "$SRC_DIR" -B "$BUILD_DIR" \
+      -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
+      -DANDROID_ABI="$ABI" \
+      -DANDROID_PLATFORM="android-$API" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+      -DCMAKE_BUILD_TYPE="$CFG" \
+      -DCMAKE_INSTALL_PREFIX="$PREFIX"
+
+    cmake --build "$BUILD_DIR" --parallel
+    cmake --install "$BUILD_DIR"
+
+    # Final required layout:
+    # <OUT_ROOT>/<OS>/<CFG>/lib/<ABI>/libfdk-aac_<ABI>.a
+    SRC_LIB="$PREFIX/lib/libfdk-aac.a"
+    DST_LIB_DIR="$PREFIX/lib/$ABI"
+    DST_LIB="$DST_LIB_DIR/libfdk-aac_${ABI}.a"
+
+    mkdir -p "$DST_LIB_DIR"
+
+    if [[ -f "$SRC_LIB" ]]; then
+      mv -f "$SRC_LIB" "$DST_LIB"
+      echo "✅ Generated: $DST_LIB"
+    else
+      echo "❌ $SRC_LIB not found"
+      echo "   Contents of $PREFIX/lib:"
+      ls -la "$PREFIX/lib" || true
+      exit 1
+    fi
+
+    echo
+  done
+done
+
+echo "🎉 Build completed successfully."
+echo "Final layout:"
+echo "  $OUT_ROOT/$OS_NAME/<Debug|Release>/lib/<ABI>/libfdk-aac_<ABI>.a"
+echo "  $OUT_ROOT/$OS_NAME/<Debug|Release>/include/..."
+

--- a/build_windows_all.bat
+++ b/build_windows_all.bat
@@ -1,0 +1,115 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM ===============================
+REM CONFIG
+REM ===============================
+if "%SRC_DIR%"=="" set "SRC_DIR=%CD%"
+if "%OUT_ROOT%"=="" set "OUT_ROOT=%SRC_DIR%\install"
+if "%BUILD_ROOT%"=="" set "BUILD_ROOT=%SRC_DIR%\build"
+if "%OS_NAME%"=="" set "OS_NAME=Windows"
+
+set "GENERATOR=Visual Studio 16 2019"
+set "CONFIGS=Debug Release"
+
+REM Map VS architecture -> folder name
+REM Win32  -> x86
+REM x64    -> x86_64
+
+REM ===============================
+REM CHECKS
+REM ===============================
+where cmake >nul 2>nul
+if errorlevel 1 (
+    echo ❌ cmake not found in PATH.
+    exit /b 1
+)
+
+if not exist "%SRC_DIR%\CMakeLists.txt" (
+    echo ❌ CMakeLists.txt not found in %SRC_DIR%
+    exit /b 1
+)
+
+if not exist "%OUT_ROOT%" mkdir "%OUT_ROOT%"
+if not exist "%BUILD_ROOT%" mkdir "%BUILD_ROOT%"
+
+echo.
+echo Source   : %SRC_DIR%
+echo Install  : %OUT_ROOT%\%OS_NAME%
+echo Build    : %BUILD_ROOT%\%OS_NAME%
+echo.
+
+REM ===============================
+REM BUILD LOOP
+REM ===============================
+for %%A in (Win32 x64) do (
+
+    REM Map architecture name
+    if "%%A"=="Win32" (
+        set "ARCH_FOLDER=x86"
+    ) else (
+        set "ARCH_FOLDER=x86_64"
+    )
+
+    set "BUILD_DIR=%BUILD_ROOT%\%OS_NAME%\%%A\vs"
+    if not exist "!BUILD_DIR!" mkdir "!BUILD_DIR!"
+
+    echo ======================================
+    echo Configuring: %%A  -> folder: !ARCH_FOLDER!
+    echo ======================================
+
+    cmake -S "%SRC_DIR%" -B "!BUILD_DIR!" ^
+        -G "%GENERATOR%" ^
+        -A %%A ^
+        -DBUILD_SHARED_LIBS=OFF
+
+    if errorlevel 1 exit /b 1
+
+    for %%C in (%CONFIGS%) do (
+
+        set "PREFIX=%OUT_ROOT%\%OS_NAME%\%%C"
+        if not exist "!PREFIX!" mkdir "!PREFIX!"
+
+        echo --------------------------------------
+        echo Building: ARCH=%%A  Config=%%C
+        echo --------------------------------------
+
+        cmake --build "!BUILD_DIR!" --config %%C --parallel
+        if errorlevel 1 exit /b 1
+
+        cmake --install "!BUILD_DIR!" --config %%C --prefix "!PREFIX!"
+        if errorlevel 1 exit /b 1
+
+        REM Locate generated static lib (keep original name)
+        set "SRC_LIB=!PREFIX!\lib\fdk-aac.lib"
+        if not exist "!SRC_LIB!" set "SRC_LIB=!PREFIX!\lib\libfdk-aac.lib"
+
+        if not exist "!SRC_LIB!" (
+            echo ❌ Static library not found in !PREFIX!\lib
+            exit /b 1
+        )
+
+        REM Destination folder with normalized arch name
+        set "DST_DIR=!PREFIX!\lib\!ARCH_FOLDER!"
+        if not exist "!DST_DIR!" mkdir "!DST_DIR!"
+
+        REM Extract filename safely
+        for %%F in ("!SRC_LIB!") do (
+            set "LIBNAME=%%~nxF"
+        )
+
+        move /Y "!SRC_LIB!" "!DST_DIR!\!LIBNAME!" >nul
+
+        echo ✅ Generated: !DST_DIR!\!LIBNAME!
+        echo.
+    )
+)
+
+echo ======================================
+echo 🎉 Windows build completed successfully
+echo Layout:
+echo   %OUT_ROOT%\%OS_NAME%\^<Debug^|Release^>\lib\x86\
+echo   %OUT_ROOT%\%OS_NAME%\^<Debug^|Release^>\lib\x86_64\
+echo ======================================
+
+endlocal

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,46 @@
+import os
+from conans import ConanFile
+from conans import tools
+
+class Fdk_aacConan(ConanFile): 
+    settings    = "os", "compiler", "build_type", "arch"
+    description = "Package for fdk_aac "
+    url = "None"
+    license = "None"
+    generators = "qmake"
+    keep_imports=True
+    no_copy_source=True
+    #requires = qt_exact_requirements(super)
+
+    def getEnvs(self):
+        pass
+
+    def package_info(self):
+        if self.settings.os == 'Android':
+            if self.settings.arch == 'armv7':
+                self.cpp_info.libdirs = ["lib/armeabi-v7a"]
+            elif self.settings.arch == 'armv8':
+                self.cpp_info.libdirs = ["lib/arm64-v8a"]
+            elif self.settings.arch == 'x86_64':
+                self.cpp_info.libdirs = ["lib/x86_64"]
+            elif self.settings.arch == 'x86':
+                self.cpp_info.libdirs = ["lib/x86"]
+
+        self.cpp_info.libs = tools.collect_libs(self)
+
+    def package(self):
+        if self.settings.os == 'Android':
+            self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "include"), dst="include")
+            if self.settings.arch == 'armv7':
+                self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "lib/armeabi-v7a"), dst="lib/armeabi-v7a")
+            elif self.settings.arch == 'armv8':
+                self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "lib/arm64-v8a"), dst="lib/arm64-v8a")
+            elif self.settings.arch == 'x86_64':
+                self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "lib/x86_64"), dst="lib/x86_64")
+            elif self.settings.arch == 'x86':
+                self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "lib/x86"), dst="lib/x86")
+            else:
+                print('Android architecture not supported = '+ self.settings.arch)
+        else:
+            self.copy("*", src=os.path.join(str(self.settings.os), str(self.settings.build_type)))
+

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,8 +29,8 @@ class Fdk_aacConan(ConanFile):
         self.cpp_info.libs = tools.collect_libs(self)
 
     def package(self):
+        self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "include"), dst="include")
         if self.settings.os == 'Android':
-            self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "include"), dst="include")
             if self.settings.arch == 'armv7':
                 self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "lib/armeabi-v7a"), dst="lib/armeabi-v7a")
             elif self.settings.arch == 'armv8':
@@ -41,6 +41,11 @@ class Fdk_aacConan(ConanFile):
                 self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "lib/x86"), dst="lib/x86")
             else:
                 print('Android architecture not supported = '+ self.settings.arch)
+        elif self.settings.os == 'Windows':
+            if self.settings.arch == 'x86_64':
+                self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "lib/x86_64"), dst="lib")
+            if self.settings.arch == 'x86':
+                self.copy("*", src=os.path.join("install", str(self.settings.os), str(self.settings.build_type), "lib/x86"), dst="lib")
         else:
-            self.copy("*", src=os.path.join(str(self.settings.os), str(self.settings.build_type)))
+            print('OS not supported = '+ self.settings.os)
 


### PR DESCRIPTION
Add build scripts for Android and Windows:

The script creates all artifacts for these ABIS and in Debug and Release configuration

**Android** (android_build_all.sh)
- x86
- x86_64
- armeabi-v7a
- arm64-v8a

**Windows** (windows_build_all.bat)
- x86
- x86_64

Add build documentation